### PR TITLE
Pass basic authentication parameters to critical process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # OS or Editor folders
 .DS_Store
 .idea
-
-
+vendor

--- a/src/Provider/DefaultProvider.php
+++ b/src/Provider/DefaultProvider.php
@@ -36,7 +36,7 @@ class DefaultProvider implements ProviderInterface
 
         $urls = [];
         foreach ($options as $option) {
-            $urls[$option] =  $store->getUrl('m2bp/criticalCss/default', ['page_layout' => $option]);
+            $urls[$option] = $store->getUrl('m2bp/criticalCss/default', ['page_layout' => $option]);
         }
         return $urls;
     }

--- a/src/Service/CriticalCss.php
+++ b/src/Service/CriticalCss.php
@@ -15,7 +15,6 @@ class CriticalCss
 
     public function __construct(ProcessFactory $processFactory)
     {
-
         $this->processFactory = $processFactory;
     }
 

--- a/src/Service/ProcessManager.php
+++ b/src/Service/ProcessManager.php
@@ -7,7 +7,6 @@ use M2Boilerplate\CriticalCss\Config\Config;
 use M2Boilerplate\CriticalCss\Model\ProcessContext;
 use M2Boilerplate\CriticalCss\Provider\Container;
 use M2Boilerplate\CriticalCss\Provider\ProviderInterface;
-use Magento\Framework\App\Cache\TypeListInterface;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\App\Emulation;
 use Magento\Store\Model\StoreManagerInterface;
@@ -148,7 +147,9 @@ class ProcessManager
             $process = $this->criticalCssService->createCriticalCssProcess(
                 $url,
                 $this->config->getDimensions(),
-                $this->config->getCriticalBinary()
+                $this->config->getCriticalBinary(),
+                $this->config->getUsername(),
+                $this->config->getPassword()
             );
             $context = $this->contextFactory->create([
                 'process' => $process,


### PR DESCRIPTION
I noticed that the basic authentication settings were not passed to the critical process, so I added them here.