### PR TITLE
Ignore main-css-loader to enable Vanilla loader behavior

### DIFF
--- a/src/Service/CriticalCss.php
+++ b/src/Service/CriticalCss.php
@@ -44,7 +44,8 @@ class CriticalCss
 
         $command[] = '--strict';
         $command[] = '--no-request-https.rejectUnauthorized';
-        $command[] = "--ignore-rule '[data-role=main-css-loader]'";
+        $command[] = '--ignore-rule';
+        $command[] = '[data-role=main-css-loader]';
 
         /** @var Process $process */
         $process = $this->processFactory->create(['command' => $command, 'commandline' => $command]);


### PR DESCRIPTION
The display: none rule for main-css-loader should not be in the critical css so its functionality is enabled.

Fixes https://github.com/m2-boilerplate/Module-Critical-CSS/issues/17